### PR TITLE
[Chore] Bump GHC tested-with to 9.2.8

### DIFF
--- a/hsblst.cabal
+++ b/hsblst.cabal
@@ -19,7 +19,7 @@ license-file:   LICENSE
 build-type:     Simple
 tested-with:
     GHC == 9.0.2
-  , GHC == 9.2.7
+  , GHC == 9.2.8
   , GHC == 9.4.5
 extra-source-files:
     README.md

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ license: MPL-2.0
 
 tested-with:
   - GHC == 9.0.2
-  - GHC == 9.2.7
+  - GHC == 9.2.8
   - GHC == 9.4.5
 
 default-extensions:


### PR DESCRIPTION
## Description

Problem: stack LTS is now using GHC 9.2.8

Solution: update tested-with

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
