### PR TITLE
[Chore] Add noinline pragmas to uses of unsafePerformIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
    - SPDX-License-Identifier: MPL-2.0
    -->
 
+## v0.0.2
+
+* Prevent inlining of foreign calls. This fixes a potential efficiency issue,
+  but it shouldn't affect correctness.
+
 ## v0.0.1
 
 * Initial release

--- a/hsblst.cabal
+++ b/hsblst.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hsblst
-version:        0.0.1
+version:        0.0.2
 synopsis:       Haskell bindings to BLST
 description:    HsBLST is low-level Haskell bindings and a high-level interface to [BLST](https://github.com/supranational/blst) -- a multilingual BLS12-381 signature library.
 category:       Cryptography

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: hsblst
-version: 0.0.1
+version: 0.0.2
 author: Serokell <hi@serokell.io>
 github: serokell/hsblst
 

--- a/test/Test/BLST/Fixtures.hs
+++ b/test/Test/BLST/Fixtures.hs
@@ -51,6 +51,7 @@ msg = "hello, world!"
 
 expectedKey :: B.Scalar
 expectedKey = unsafePerformIO $ B.scalarFromLendian $ fromHex expectedSerKey
+{-# NOINLINE expectedKey #-}
 
 expectedSerKey :: Text
 expectedSerKey =
@@ -155,6 +156,7 @@ expectedSignHash1 = deserializePoint
 
 expectedAffSignHash1 :: B.Affine 'B.P2
 expectedAffSignHash1 = unsafePerformIO $ B.p2ToAffine expectedSignHash1
+{-# NOINLINE expectedAffSignHash1 #-}
 
 expectedSignHash2 :: B.Point 'B.P1
 expectedSignHash2 = deserializePoint
@@ -167,6 +169,7 @@ expectedSignHash2 = deserializePoint
 
 expectedAffSignHash2 :: B.Affine 'B.P1
 expectedAffSignHash2 = unsafePerformIO $ B.p1ToAffine expectedSignHash2
+{-# NOINLINE expectedAffSignHash2 #-}
 
 expectedSignEnc1 :: B.Point 'B.P2
 expectedSignEnc1 = deserializePoint
@@ -185,6 +188,7 @@ expectedSignEnc1 = deserializePoint
 
 expectedAffSignEnc1 :: B.Affine 'B.P2
 expectedAffSignEnc1 = unsafePerformIO $ B.p2ToAffine expectedSignEnc1
+{-# NOINLINE expectedAffSignEnc1 #-}
 
 expectedSignEnc2 :: B.Point 'B.P1
 expectedSignEnc2 = deserializePoint
@@ -197,6 +201,7 @@ expectedSignEnc2 = deserializePoint
 
 expectedAffSignEnc2 :: B.Affine 'B.P1
 expectedAffSignEnc2 = unsafePerformIO $ B.p1ToAffine expectedSignEnc2
+{-# NOINLINE expectedAffSignEnc2 #-}
 
 expectedAffPk1 :: B.Affine 'B.P1
 expectedAffPk1 = deserializeAffine' expectedSer1

--- a/test/Test/BLST/Util.hs
+++ b/test/Test/BLST/Util.hs
@@ -40,12 +40,15 @@ toHex = encodeHex . BA.convert . AS.unSizedByteArray
 
 deserializePoint :: C.IsPoint p => Text -> B.Point p
 deserializePoint = unsafePerformIO . C.fromAffine . deserializeAffine
+{-# NOINLINE deserializePoint #-}
 
 deserializePoint' :: C.IsPoint p => SizedByteArray (C.SerializedSize p) Bytes -> B.Point p
 deserializePoint' = unsafePerformIO . C.fromAffine . deserializeAffine'
+{-# NOINLINE deserializePoint' #-}
 
 deserializeAffine :: C.IsPoint p => Text -> B.Affine p
 deserializeAffine = deserializeAffine' . fromHex
 
 deserializeAffine' :: C.IsPoint p => SizedByteArray (C.SerializedSize p) Bytes -> B.Affine p
 deserializeAffine' = unsafePerformIO . fmap (either (error . show) id) . C.deserialize
+{-# NOINLINE deserializeAffine' #-}


### PR DESCRIPTION
## Description

Problem: some blst foreign calls can be performed multiple times if high-level functions get inlined. This is only an efficiency, and not correctness issue.

Solution: Add noinline pragmas to all functions using unsafePerformIO.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
