### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     name: Verify cross references
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: serokell/xrefcheck-action@v1
       with:
         xrefcheck-version: '0.2.2'
@@ -34,7 +34,7 @@ jobs:
     if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1
 
@@ -42,7 +42,7 @@ jobs:
     if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: haskell/actions/hlint-setup@v2
         with:
           version: '3.5'
@@ -55,7 +55,7 @@ jobs:
     if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache binaries
         id: cache-stylish
         uses: actions/cache@v3
@@ -82,7 +82,7 @@ jobs:
     name: Find Trailing Whitespace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: harupy/find-trailing-whitespace@v1.0
 
   cabal:
@@ -97,7 +97,7 @@ jobs:
         ghc: ${{ fromJSON(needs.collect-ghc-versions.outputs.ghcvers) }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
 
@@ -150,7 +150,7 @@ jobs:
     outputs:
       ghcvers: ${{ steps.ghcvers.outputs.ghcvers }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: ghcvers
       run: |
         echo -n "ghcvers=" >> "$GITHUB_OUTPUT"
@@ -172,7 +172,7 @@ jobs:
         GHCVER=$(curl -L https://www.stackage.org/${{ matrix.resolver }}/ghc-major-version)
         echo "ghcver=$GHCVER" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
 
@@ -237,7 +237,7 @@ jobs:
     name: Validate cabal files
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
 


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
