### PR TITLE
Move to ram to align with latest hackage crypton and fix cabal to bui…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
    - SPDX-License-Identifier: MPL-2.0
    -->
 
+## v0.0.5
+
+* Moved to ram instead of memory
+* Added ForeignFunctionInterface to extensions for cabal to build successfully
 ## v0.0.4
 
 * Bundled blst version bumped to v0.3.13

--- a/hsblst.cabal
+++ b/hsblst.cabal
@@ -181,6 +181,7 @@ library
       EmptyCase
       FlexibleContexts
       FlexibleInstances
+      ForeignFunctionInterface
       GADTs
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
@@ -219,7 +220,7 @@ library
   build-depends:
       base >=4.17 && <4.22
     , deepseq >=1.4.5.0 && <1.6.0
-    , memory >=0.16.0 && <0.19
+    , ram >=0.19 && < 0.22
   default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
@@ -296,7 +297,7 @@ test-suite hsblst-test
     , base16-bytestring ==1.0.*
     , bytestring >=0.10.12.1 && <0.13
     , hsblst
-    , memory >=0.16.0 && <0.19
+    , ram >=0.19 && < 0.22
     , tasty >=1.4.2.1 && <1.6
     , tasty-hunit >=0.10.0.3 && <0.11
     , text >=1.2.5.0 && <1.3 || >=2.0.1 && <2.1 || >=2.1 && <2.2

--- a/hsblst.cabal
+++ b/hsblst.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.0
 -- see: https://github.com/sol/hpack
 
 name:           hsblst
-version:        0.0.4
+version:        0.0.5
 synopsis:       Haskell bindings to BLST
 description:    HsBLST is low-level Haskell bindings and a high-level interface to [BLST](https://github.com/supranational/blst) -- a multilingual BLS12-381 signature library.
 category:       Cryptography


### PR DESCRIPTION
…ld FFI modules

## Description

Crypton > 1.1.0 has moved to ram instead of memory. By moving hsblst to ram as well using it alongside crypton is now possible.

The addition of ForeignFunctionInterface to the library extensions also fixes the cabal build.

## Related issue(s)
None 

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [X ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ X] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

  - [ X] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ X] My code complies with the [style guide](../tree/master/docs/code-style.md).
